### PR TITLE
Reduce self update errors

### DIFF
--- a/package/yast2-installation.changes
+++ b/package/yast2-installation.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 14 14:55:08 UTC 2017 - igonzalezsosa@suse.com
+
+- Self-Update only shows errors when a custom URL is used
+  (bsc#1025251)
+- 3.2.22
+
+-------------------------------------------------------------------
 Wed Feb  8 16:42:29 UTC 2017 - kanderssen@suse.com
 
 - CaaSP all-in-one-dialog: added validation to the controller node

--- a/package/yast2-installation.spec
+++ b/package/yast2-installation.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-installation
-Version:        3.2.21
+Version:        3.2.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -230,11 +230,14 @@ module Yast
       false
 
     rescue ::Installation::UpdatesManager::CouldNotFetchUpdateFromRepo
+      if repo.user_defined?
       # TRANSLATORS: %s is an URL
-      Report.Error(format(_("Could not fetch update from\n%s.\n\n"), repo.uri))
+        Report.Error(format(_("Could not fetch update from\n%s.\n\n"), repo.uri))
+      end
       false
 
     rescue ::Installation::UpdatesManager::CouldNotProbeRepo
+      return false unless repo.user_defined?
       msg = could_not_probe_repo_msg(repo.uri)
       if Mode.auto
         Report.Warning(msg)

--- a/src/lib/installation/clients/inst_update_installer.rb
+++ b/src/lib/installation/clients/inst_update_installer.rb
@@ -216,7 +216,7 @@ module Yast
 
     # Add a repository to the updates manager
     #
-    # @param repository [UpdateRepository] Update repository to add
+    # @param repo [UpdateRepository] Update repository to add
     # @return [Boolean] true if the repository was added; false otherwise.
     def add_repository(repo)
       log.info("Adding update from #{repo.inspect}")

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -272,7 +272,7 @@ module Installation
     # Runs a block of code handling errors
     #
     # If errors should be shown, the helper {catch_registration_errors}
-    # from Registration::ConnectionHelpers will be used.
+    # from Registration::ConnectHelpers will be used.
     #
     # Otherwise, errors will be logged and the method will return +false+.
     #
@@ -280,12 +280,12 @@ module Installation
     # @return [false, Object] The value returned by the block itself. False
     #                         if the block failed.
     #
-    # @see Registration::ConnectionHelpers.catch_registration_errors
+    # @see Registration::ConnectHelpers.catch_registration_errors
     def handle_registration_errors(show_errors)
       if show_errors
-        require "registration/connection_helpers"
+        require "registration/connect_helpers"
         ret = nil
-        success = ::Registration::ConnectionHelpers.catch_registration_errors { ret = yield }
+        success = ::Registration::ConnectHelpers.catch_registration_errors { ret = yield }
         success && ret
       else
         begin

--- a/src/lib/installation/update_repositories_finder.rb
+++ b/src/lib/installation/update_repositories_finder.rb
@@ -53,7 +53,7 @@ module Installation
     # It tries to find an URL in Linuxrc boot parameters and
     # AutoYaST profile.
     #
-    # @return [UpdateRepository,nil] self-update repository or nil is not defined
+    # @return [UpdateRepository,nil] self-update repository or nil if not defined
     #
     # @see update_url_from_linuxrc
     # @see update_url_from_profile
@@ -276,7 +276,7 @@ module Installation
     #
     # Otherwise, errors will be logged and the method will return +false+.
     #
-    # @params [Boolean] True if errors should be shown to the user. False otherwise.
+    # @param [Boolean] show_errors True if errors should be shown to the user. False otherwise.
     # @return [false, Object] The value returned by the block itself. False
     #                         if the block failed.
     #
@@ -291,7 +291,7 @@ module Installation
         begin
           yield
         rescue StandardError => e
-          log.error("Could not determine update repositories through the registration server: " \
+          log.warn("Could not determine update repositories through the registration server: " \
             "#{e.class}: #{e}, #{e.backtrace}")
           false
         end

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -122,7 +122,14 @@ module Installation
       @origin = origin
     end
 
+    # Returns the repository ID
+    #
+    # As a potential side-effect, the repository will be added to libzypp (if it
+    # was not added yet) in order to get the ID.
+    #
     # @return [Fixnum] yast2-pkg-bindings ID of the repository
+    #
+    # @see add_repo
     def repo_id
       add_repo
     end
@@ -331,6 +338,9 @@ module Installation
     end
 
     # Add the repository to libzypp sources
+    #
+    # If the repository was already added, it will just simply return
+    # the repository ID.
     #
     # @return [Integer] Repository ID
     #

--- a/src/lib/installation/update_repository.rb
+++ b/src/lib/installation/update_repository.rb
@@ -16,6 +16,10 @@ require "tempfile"
 require "pathname"
 require "fileutils"
 
+Yast.import "Pkg"
+Yast.import "Progress"
+Yast.import "URL"
+
 module Installation
   # Represents a update repository to be used during self-update
   # (check doc/SELF_UPDATE.md for details).
@@ -109,9 +113,6 @@ module Installation
     # @param uri                [URI]      Repository URI
     # @param origin             [Symbol]   Repository origin (@see ORIGINS)
     def initialize(uri, origin = :default)
-      Yast.import "Pkg"
-      Yast.import "Progress"
-
       textdomain "installation"
 
       @uri = uri
@@ -255,6 +256,14 @@ module Installation
     # @see Pkg.UrlSchemeIsRemote
     def remote?
       Yast::Pkg.UrlSchemeIsRemote(uri.scheme)
+    end
+
+    # Redefines the inspect method to avoid logging passwords
+    #
+    # @return [String] Debugging information
+    def inspect
+      safe_url = Yast::URL.HidePassword(uri.to_s)
+      "#<Installation::UpdateRepository> @uri=\"#{safe_url}\" @origin=#{@origin.inspect}"
     end
 
   private

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -20,6 +20,8 @@ describe Installation::UpdateRepositoriesFinder do
 
     before do
       stub_const("Yast::Profile", ay_profile)
+      stub_const("::Registration::ConnectionHelpers", FakeConnectionHelpers)
+      allow(finder).to receive(:require).with("registration/connection_helpers")
       allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
         .and_return(url_from_linuxrc)
     end
@@ -144,6 +146,12 @@ describe Installation::UpdateRepositoriesFinder do
                 .with(URI(update0.url), :default).and_return(repo)
               finder.updates
             end
+
+            it "handles registration errors" do
+              expect(Registration::ConnectionHelpers).to receive(:catch_registration_errors)
+                .and_call_original
+              finder.updates
+            end
           end
 
           context "if user cancels the dialog" do
@@ -174,6 +182,11 @@ describe Installation::UpdateRepositoriesFinder do
               .with(URI(update1.url), :default).and_return(repo)
             finder.updates
           end
+
+          it "does not handles registration errors" do
+            expect(Registration::ConnectionHelpers).to_not receive(:catch_registration_errors)
+            finder.updates
+          end
         end
 
         context "when a regurl was specified via Linuxrc" do
@@ -182,6 +195,12 @@ describe Installation::UpdateRepositoriesFinder do
           it "asks the SCC server for the updates URLs" do
             expect(registration_class).to receive(:new).with(regurl)
               .and_return(registration)
+            finder.updates
+          end
+
+          it "handles registration errors" do
+            expect(Registration::ConnectionHelpers).to receive(:catch_registration_errors)
+              .and_call_original
             finder.updates
           end
         end

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -183,7 +183,7 @@ describe Installation::UpdateRepositoriesFinder do
             finder.updates
           end
 
-          it "does not handles registration errors" do
+          it "does not handle registration errors" do
             expect(Registration::ConnectHelpers).to_not receive(:catch_registration_errors)
             finder.updates
           end

--- a/test/lib/update_repositories_finder_test.rb
+++ b/test/lib/update_repositories_finder_test.rb
@@ -20,8 +20,8 @@ describe Installation::UpdateRepositoriesFinder do
 
     before do
       stub_const("Yast::Profile", ay_profile)
-      stub_const("::Registration::ConnectionHelpers", FakeConnectionHelpers)
-      allow(finder).to receive(:require).with("registration/connection_helpers")
+      stub_const("::Registration::ConnectHelpers", FakeConnectHelpers)
+      allow(finder).to receive(:require).with("registration/connect_helpers")
       allow(Yast::Linuxrc).to receive(:InstallInf).with("SelfUpdate")
         .and_return(url_from_linuxrc)
     end
@@ -148,7 +148,7 @@ describe Installation::UpdateRepositoriesFinder do
             end
 
             it "handles registration errors" do
-              expect(Registration::ConnectionHelpers).to receive(:catch_registration_errors)
+              expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)
                 .and_call_original
               finder.updates
             end
@@ -184,7 +184,7 @@ describe Installation::UpdateRepositoriesFinder do
           end
 
           it "does not handles registration errors" do
-            expect(Registration::ConnectionHelpers).to_not receive(:catch_registration_errors)
+            expect(Registration::ConnectHelpers).to_not receive(:catch_registration_errors)
             finder.updates
           end
         end
@@ -199,7 +199,7 @@ describe Installation::UpdateRepositoriesFinder do
           end
 
           it "handles registration errors" do
-            expect(Registration::ConnectionHelpers).to receive(:catch_registration_errors)
+            expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)
               .and_call_original
             finder.updates
           end

--- a/test/support/fake_registration.rb
+++ b/test/support/fake_registration.rb
@@ -10,7 +10,7 @@ class FakeRegConfig
   def import(_args); end
 end
 
-module FakeConnectionHelpers
+module FakeConnectHelpers
   def self.catch_registration_errors
     yield
     true

--- a/test/support/fake_registration.rb
+++ b/test/support/fake_registration.rb
@@ -9,3 +9,10 @@ class FakeRegConfig
   include Singleton
   def import(_args); end
 end
+
+module FakeConnectionHelpers
+  def self.catch_registration_errors
+    yield
+    true
+  end
+end


### PR DESCRIPTION
As you may know, YaST includes a nice feature which allows the installer to update itself in order to solve bugs in the installation media. This mechanism has been included in SUSE Linux Enterprise 12 SP2, although it's not enabled by default (you need to pass an extra option `selfupdate=1` to make it work).

So after getting some feedback, we're working toward fixing some usability problems. The first of them is that, in some situations, the self-update mechanism is too intrusive.

Consider the following scenario: you're installing a system behind a firewall which prevents the machine to connect to the outside network. As the SUSE Customer Center will be unreachable, YaST complains about not being able to get the list of repositories for the self-update. And, after that, you get another complain because the fallback repository is not accessible. Two error messages and 2 timeouts.

And the situation could be even worse if you don't have access to a DNS server (add another error message).

So after some discussion we've decided to show such errors only if the user has specified SMT or a custom self-update repository (which is also possible). In any other case, the error is logged and the self-update is skipped completely.

You can find further information in our [Self-Update Use Cases and Error Handling dcument](https://gist.github.com/imobachgs/cb03b6a87dd5e31c89a9463d30db4252).

During upcoming sprints, we'll keep working on making the self-update feature great!